### PR TITLE
Allow threshold_values in an instrument's data.json file

### DIFF
--- a/js/instrument/tw.instrument.number.js
+++ b/js/instrument/tw.instrument.number.js
@@ -26,14 +26,14 @@ teamwall.instrument.number = function (configuration) {
             if (data.decimal_places && data.decimal_places > 0) {
                 value = teamwall.math.round(data.value, 1);
             }
-            drawInstrument(value, data.trend, data.date);
+            drawInstrument(value, data.threshold_value, data.trend, data.date);
         };
 
         this.getConfiguration = function () {
             return instrumentConfiguration;
         };
 
-        function drawInstrument(value, trend, date) {
+        function drawInstrument(value, threshold, trend, date) {
             var canvas = document.getElementById(instrumentConfiguration.id);
             var context = canvas.getContext("2d");
             var centerX = canvas.width / 2;
@@ -44,7 +44,7 @@ teamwall.instrument.number = function (configuration) {
             context.fillRect(0, 0, canvas.width, canvas.height);
 
             teamwall.render.writeText(context, instrumentConfiguration.title, centerX, teamwall.render.yPointForDrawingHeading(canvas), teamwall.render.fontForHeader(canvas), teamwall.configuration.colorText);
-            showThreshold(value, context, centerX, canvas);
+            showThreshold(value, threshold, context, centerX, canvas);
             teamwall.render.writeText(context, value, centerX, centerY, getFontWithRightSize(canvas, context, value), teamwall.configuration.colorText);
             showTrend(trend, context, canvas);
             if (helpLines) {
@@ -57,7 +57,9 @@ teamwall.instrument.number = function (configuration) {
 
         }
 
-        function showThreshold(value, context, centerX, canvas) {
+        function showThreshold(value, threshold, context, centerX, canvas) {
+            if (threshold)
+                instrumentConfiguration.threshold_value = threshold;
             if (instrumentConfiguration.threshold_value != undefined) {
                 var thresholdColor = teamwall.configuration.colorOk;
                 var thresholdToActualDifference = teamwall.math.round(value - instrumentConfiguration.threshold_value, 1);

--- a/js/instrument/tw.instrument.percent.js
+++ b/js/instrument/tw.instrument.percent.js
@@ -19,7 +19,7 @@ teamwall.instrument.percent = function (configuration) {
 
         this.setValue = function (data) {
             var targetValue = teamwall.math.round(data.value, 1);
-            drawInstrument(targetValue, data.trend);
+            drawInstrument(targetValue, data.threshold_value, data.trend);
             currentValue = targetValue;
         };
 
@@ -27,7 +27,7 @@ teamwall.instrument.percent = function (configuration) {
             return instrumentConfiguration;
         };
 
-        function drawInstrument(value, trend) {
+        function drawInstrument(value, threshold, trend) {
             var canvas = document.getElementById(instrumentConfiguration.id);
             var context = canvas.getContext("2d");
             var centerX = canvas.width / 2;
@@ -42,6 +42,9 @@ teamwall.instrument.percent = function (configuration) {
             context.clearRect(0, 0, canvas.width, canvas.height);
             context.fillStyle = teamwall.configuration.background;
             context.fillRect(0, 0, canvas.width, canvas.height);
+
+            if (threshold)
+                instrumentConfiguration.threshold_value = threshold;
 
             var valueColor = teamwall.configuration.colorOk;
             if (value < instrumentConfiguration.threshold_value) {


### PR DESCRIPTION
Changed drawInstrument functions for 'number' and 'percent' Teamwall instruments so that you can provide a threshold_value in the data.json file itself.

e.g. your data.json file for an instrument could look like:
`{"value":"53", "threshold_value":"45", "trend":"1"}`

A threshold_value set in the data.json file will override any threshold_value set in the instrument json itself.

In this way, you can create instruments where the value AND the threshold will change dynamically when the data.json file is updated.
