### PR TITLE
font of a broken build scales now with the size of the buildalert instrument

### DIFF
--- a/js/instrument/tw.instrument.buildAlert.js
+++ b/js/instrument/tw.instrument.buildAlert.js
@@ -1,10 +1,3 @@
-/*
- {
- "instrument":"buildalert",
- "id":"buildalert",
- "url":"data/buildalert.json"
- }
- */
 teamwall.instrument.buildAlert = function (configuration) {
 
     function BuildAlertInstrument(configuration) {
@@ -42,27 +35,26 @@ teamwall.instrument.buildAlert = function (configuration) {
                 headerHeight = canvas.height * 0.1;
                 contentHeight = canvas.height * 0.9;
 
-                var buildAlertTitleWithCount = ((failedBuilds.length > 0) ? failedBuilds.length + " " : "No ") + instrumentConfiguration.title;
+                var buildAlertTitleWithCount = ((failedBuilds.builds.length > 0) ? failedBuilds.builds.length + " " : "No ") + instrumentConfiguration.title;
                 var buildAlertTitle = (instrumentConfiguration.showCount == true) ? buildAlertTitleWithCount : instrumentConfiguration.title;
                 teamwall.render.writeText(context, buildAlertTitle, centerX, teamwall.render.yPointForDrawingHeading(canvas), teamwall.render.fontForHeader(canvas), teamwall.configuration.colorText);
             }
 
-            var fontScaleFactorPercentage = 90/failedBuilds.length/2;
-            context.font = teamwall.render.font(canvas, fontScaleFactorPercentage);
             context.textBaseline = "middle";
             context.textAlign = "center";
+            teamwall.render.perfectFont(context, failedBuilds.longestText, canvas.width * 0.9);
 
             var numberOfBuildChains = value.length;
             if (0 < numberOfBuildChains) {
-                if (0 < failedBuilds.length) {
+                if (0 < failedBuilds.builds.length) {
                     context.fillStyle = teamwall.configuration.colorFailure;
                     context.fillRect(0, 0 + headerHeight, canvas.width, contentHeight);
                     context.fillStyle = teamwall.configuration.colorText;
-                    var heightOfOneBlock = contentHeight / failedBuilds.length;
+                    var heightOfOneBlock = contentHeight / failedBuilds.builds.length;
                     var part = 0;
-                    jQuery.each(failedBuilds, function () {
-                        var failedBuild = this;
-                        context.fillText(failedBuild.chain.name + " " + failedBuild.part.name, centerX, part * heightOfOneBlock + (heightOfOneBlock / 2) + headerHeight, canvas.width);
+                    jQuery.each(failedBuilds.builds, function () {
+                        var brokenBuildName = this;
+                        context.fillText(brokenBuildName, centerX, part * heightOfOneBlock + (heightOfOneBlock / 2) + headerHeight, canvas.width); // * 0.9);
                         part++;
                     });
 
@@ -95,7 +87,7 @@ teamwall.instrument.buildAlert = function (configuration) {
                         allGoodText = instrumentConfiguration.noAlertText;
                     }
                     var centerY = contentHeight / 2;
-                    context.fillText(allGoodText, centerX, centerY+ headerHeight, canvas.width);
+                    context.fillText(allGoodText, centerX, centerY+ headerHeight, canvas.width * 0.9);
                 }
             }
             else {
@@ -103,19 +95,22 @@ teamwall.instrument.buildAlert = function (configuration) {
             }
 
             function findFailedBuilds() {
-                var failedBuilds = [];
+                var failedBuilds = {"longestText": "", builds: []};
                 jQuery.each(value, function () {
                     var buildChain = this;
                     jQuery.each(buildChain.chain, function () {
                         var buildChainPart = this;
                         if (buildChainPart.status != "SUCCESS") {
-                            failedBuilds.push({"chain": buildChain, "part": buildChainPart});
+                            var brokenBuildName = buildChain.name + " " + buildChainPart.name;
+                            if (brokenBuildName.length > failedBuilds.longestText.length) {
+                                failedBuilds.longestText = brokenBuildName;
+                            }
+                            failedBuilds.builds.push(brokenBuildName);
                         }
                     });
                 });
                 return failedBuilds;
             }
-
         }
     }
 

--- a/js/tw.render.js
+++ b/js/tw.render.js
@@ -22,6 +22,21 @@ teamwall.render.font = function (canvas, percentHeight) {
     return font;
 };
 
+teamwall.render.perfectFont = function (context, longestText) {
+    var textWidth;
+    var fontSize = 10;
+    var fontSizeIncrement = 2;
+    var eightyPercentOfWidth = context.canvas.width*0.8;
+    do {
+        context.font = fontSize + "pt " + teamwall.configuration.font;
+        var metrics = context.measureText(text); // is based on canvas.width
+        textWidth = metrics.width;
+        fontSize += fontSizeIncrement;
+    } while (textWidth < (eightyPercentOfWidth));
+    var secondToLastFontSize = (fontSize - (2 * fontSizeIncrement));
+    context.font = secondToLastFontSize + "pt " + teamwall.configuration.font;
+}
+
 teamwall.render.yPointForDrawingHeading = function (canvas) {
     return canvas.height / 18
 };


### PR DESCRIPTION
Created a function "perfectFont" in tw.render.js which calculates a "perfect" font based on 80% of the canvas width. 

BuildAlert now uses this function, so that on huge screens/teamwalls broken builds are easily readable.
