### PR TITLE
port and demo data location can be overwritten

### DIFF
--- a/Readme.markdown
+++ b/Readme.markdown
@@ -37,6 +37,8 @@ Drop me a line on [twitter](https://twitter.com/owehrens).
 Put everything in a directory served by a web server. You can also run
 `npm update` and `node server.js` which will start a server on port 8888. Find below a list of instruments which can be used to visualize critical
 information.
+`PORT` can be used to overwrite the default port `8888`.
+`DATA` can be used to overwrite the default location for the `teamwall.json` and its content. The `content` will be mapped to `/` (ROOT).
 
 What `you` need to do is to create a `teamwall.json` file and put it into the root directory of teamwall. This file contains
 the description of the instruments to be shown (and how they are updated). Every 15 seconds the values are updated.

--- a/demo/Readme.markdown
+++ b/demo/Readme.markdown
@@ -4,5 +4,6 @@ The demo is a kind of quick starter. It shows you the possible instruments in ac
 
 # Set up #
 
-- Copy `teamwall.json` and the `data` directory (or symlink it) into your project directory (the one which contains server.js).
+- run `DATA=demo npm start` or `DATA=demo node server.js` in the project directory (the one which contains server.js).
 - Run your server (e.g. node server.js) and visit `http:localhost:8888`
+- if you want to specify port run `PORT=8080 npm start` or `PORT=8080 node server.js`

--- a/server.js
+++ b/server.js
@@ -1,23 +1,26 @@
 (function () {
     "use strict";
     var startedAt = new Date();
+    var dataDirectory = __dirname + '/' + (process.env.DATA || '');
+    console.log('data directory: '+dataDirectory);
 
     var fs = require('fs');
-    if (!fs.existsSync('teamwall.json')) {
+    if (!fs.existsSync(dataDirectory + '/teamwall.json')) {
         console.log('Before starting, add a teamwall.json to the installation. For an example, see the demo directory');
         return;
     }
     var connect = require('connect');
     var serveStatic = require('serve-static');
     var http = require('http');
-    var PORT = 8888;
+    var PORT = process.env.PORT || 8888;
 
     var app = connect()
         .use(function (req, res, next) {
             res.setHeader("Access-Control-Allow-Origin", "*");
             return next();
         })
-        .use(serveStatic(__dirname, {'index': ['index.html']}));
+        .use('/', serveStatic(__dirname, {'index': ['index.html']}))
+        .use('/', serveStatic(dataDirectory));        
 
     var server = http.createServer(app);
     server.listen(PORT, function () {


### PR DESCRIPTION
- port can be overwritten 'PORT=8080 npm start'
- teamwall.json location can be overwritten 'DATA=demo npm start'
- this allows to start the demo without having to copy anything around
